### PR TITLE
Docs: Changed latest to main in dockerfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ custom image.
 
 
 ``` Dockerfile
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \


### PR DESCRIPTION
The tag latest uses a very old image (with very old gcc and glib). The actual "latest" is called main. This little thing cost me several hours and change will prevent other people to suffer the same.